### PR TITLE
Cli tests no env vars

### DIFF
--- a/palo_sidekick/main.py
+++ b/palo_sidekick/main.py
@@ -15,10 +15,16 @@ def cli(ctx: click.Context) -> None:
     ctx.ensure_object(dict)
     hostname = os.getenv("PANORAMA_HOSTNAME", "")
     key = os.getenv("PANORAMA_KEY", "")
-    if "" in (hostname, key):
-        click.echo("PANORAMA_HOSTNAME or PANORAMA_KEY environment variables not set.")
-        sys.exit(1)
+    validate_environment_variables(hostname, key)
     ctx.obj = Panorama(hostname, key)
+
+
+def validate_environment_variables(hostname: str, key: str) -> None:
+    if not all((hostname, key)):
+        click.echo(
+            "PANORAMA_HOSTNAME or PANORAMA_KEY environment variables not set.", err=True
+        )
+        sys.exit(1)
 
 
 @cli.group(name="list")

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,10 @@ exclude =
 console_scripts =
     palo = palo_sidekick.main:cli
 
+[coverage:report]
+exclude_lines =
+    if __name__ == .__main__.:
+
 [mypy]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,8 +1,21 @@
 import pytest
 from click.testing import CliRunner
 
-from palo_sidekick.main import cli
+from palo_sidekick.main import cli, validate_environment_variables
 from palo_sidekick.panorama import Panorama
+
+
+@pytest.mark.parametrize("hostname, key", [("", ""), ("A", ""), ("", "A")])
+def test_validate_environment_variables_fail(hostname: str, key: str) -> None:
+    with pytest.raises(SystemExit) as raised:
+        validate_environment_variables(hostname, key)
+    assert raised.value.code == 1
+
+
+def test_validate_environment_variables_success(capfd: pytest.CaptureFixture) -> None:
+    validate_environment_variables("A", "B")
+    capture = capfd.readouterr()
+    assert capture.err == ""
 
 
 def test_list_device_groups(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,3 +1,5 @@
+"""Tests for the main CLI program."""
+
 import pytest
 from click.testing import CliRunner
 
@@ -7,12 +9,20 @@ from palo_sidekick.panorama import Panorama
 
 @pytest.mark.parametrize("hostname, key", [("", ""), ("A", ""), ("", "A")])
 def test_validate_environment_variables_fail(hostname: str, key: str) -> None:
+    """
+    Tests the program exits gracefully if one of the environment
+    variables is missing.
+    """
     with pytest.raises(SystemExit) as raised:
         validate_environment_variables(hostname, key)
     assert raised.value.code == 1
 
 
 def test_validate_environment_variables_success(capfd: pytest.CaptureFixture) -> None:
+    """
+    Tests no error output is produced if valid environment variables are
+    valid.
+    """
     validate_environment_variables("A", "B")
     capture = capfd.readouterr()
     assert capture.err == ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,5 +20,5 @@ def env_vars() -> Tuple[Optional[str], Optional[str]]:
 
 
 @pytest.fixture(scope="session")
-def panorama(env_vars: Tuple[str, str]) -> Panorama:
-    return Panorama(*env_vars)
+def panorama() -> Panorama:
+    return Panorama(hostname="TEST", api_key="TEST")

--- a/tests/panorama_test.py
+++ b/tests/panorama_test.py
@@ -60,7 +60,7 @@ def test_panorama_get_connection_error_handled(
 
         with pytest.raises(SystemExit) as raised:
             panorama.get("/")
-            assert raised.value.code == 1
+        assert raised.value.code == 1
 
         expected = f"Could not establish a connection to {panorama.hostname}.\n"
         capture = capfd.readouterr()


### PR DESCRIPTION
Created tests for validating environment variables are set. PANORAMA_HOSTNAME and PANORAMA_KEY need to be set.